### PR TITLE
Fix portal not draining energy

### DIFF
--- a/src/main/java/com/supermartijn642/wormhole/portal/PortalGroup.java
+++ b/src/main/java/com/supermartijn642/wormhole/portal/PortalGroup.java
@@ -208,7 +208,7 @@ public class PortalGroup {
         for(BlockPos pos : this.shape.energyCells){
             BlockEntity entity = this.level.getBlockEntity(pos);
             if(entity instanceof IEnergyCellEntity){
-                drained += ((IEnergyCellEntity)entity).extractEnergy(energy - drained, false, null);
+                drained += ((IEnergyCellEntity)entity).extractEnergy(energy - drained, true, null);
                 if(drained >= energy)
                     break;
             }


### PR DESCRIPTION
Fixed portal not draining energy when idle on on teleport by changing drainEnergy function for it always returns as being in side the portal group like older version. this change should be made to all effected versions; likely all versions after the check to stop negative energy was added are effected by this bug.